### PR TITLE
Skip over non-Doxie SSDP responses when using discovery

### DIFF
--- a/doxieapi/api.py
+++ b/doxieapi/api.py
@@ -69,6 +69,8 @@ class DoxieScanner:
         """
         doxies = []
         for response in ssdp.discover(DOXIE_SSDP_SERVICE, mx=1, retries=3):
+            if DOXIE_SSDP_SERVICE not in response.usn:
+                continue  # skip over non-Doxie responses
             scheme, netloc, _, _, _, _ = urlparse(response.location)
             url = urlunparse((scheme, netloc, '/', '', '', ''))
             doxies.append(DoxieScanner(url))


### PR DESCRIPTION
SSDP responses will often include the root device (the one sending the
request) - if we encounter these in the list we not skip over them to
avoid errors.

Fixes: https://github.com/davea/doxieapi/issues/2