### PR TITLE
Set downloaded scan file to Doxie timestamp

### DIFF
--- a/doxieapi/api.py
+++ b/doxieapi/api.py
@@ -2,6 +2,7 @@ import os
 import time
 import json
 from configparser import ConfigParser
+from http.cookiejar import http2time
 from urllib.parse import urlparse, urlunparse, urljoin
 
 import requests
@@ -201,6 +202,10 @@ class DoxieScanner:
         with open(output_path, 'wb') as f:
             for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
                 f.write(chunk)
+        # Set file timestamp to that of the file we downloaded
+        timestamp = http2time(response.headers.get('Last-Modified'))
+        os.utime(output_path, (timestamp,)*2)
+
         return output_path
 
     def download_scans(self, output_dir):


### PR DESCRIPTION
When downloading a scan, we now update the local timestamp to match that of the file from the Doxie scanner.