### PR TITLE
Session rewrite and modern Doxie support

### DIFF
--- a/doxieapi/api.py
+++ b/doxieapi/api.py
@@ -30,6 +30,23 @@ DOXIE_ATTR_MAP = {
 DOWNLOAD_CHUNK_SIZE = 1024*8
 
 
+class DoxieResponse(requests.Response):
+    """A Response from a Doxie API call."""
+
+    def raise_for_status(self):
+        """Raises :class:`HTTPError`, if one occurred.
+        Doxie only uses 401 (Unauthorized) or 403 (Forbidden) for errors.
+
+        """
+
+        if self.status_code in (401, 403):
+            raise requests.exceptions.HTTPError(
+                u'%s Server Error: %s for url: %s' % (
+                    self.status_code, self.reason, self.url),
+                response=self,
+            )
+
+
 class DoxieScanner:
     """A client for the Doxie Scanner."""
 
@@ -120,36 +137,47 @@ class DoxieScanner:
             doxies.append(DoxieScanner(basepath))
         return doxies
 
-    def _api_url(self, path):
-        """
-        >>> doxie._api_url("/scans.json")
-        'http://192.168.100.1:8080/scans.json'
-        >>> doxie._api_url("/networks/available.json")
-        'http://192.168.100.1:8080/networks/available.json'
-        """
-        return urljoin(self.basepath, path)
+    def _get(self, path, **kwargs):
+        """Send a GET request to an endpoint."""
 
-    def _api_call(self, path, return_json=True):
-        """
-        Makes a request to the Doxie scanner on the given path,
-        authenticating if necessary.
-        Assumes the result is JSON, and returns the result of parsing it.
-        Call with return_json=False to skip the JSON parsing step.
-        """
-        url = self._api_url(path)
-        response = self._get_url(url)
-        return response.json() if return_json else None
+        response = self.session.get(
+            urljoin(self.basepath, path),
+            **kwargs,
+        )
 
-    def _get_url(self, url, stream=False):
-        """
-        Performs a GET to a URL, including authentication
-        if required.
-        Checks that the response status code is 200 before
-        returning the response.
-        """
-        response = self.session.get(url, stream=stream)
-        if response.status_code != requests.codes.ok:
-            response.raise_for_status()
+        response.__class__ = DoxieResponse
+        response.raise_for_status()
+
+        return response
+
+    def _post(self, path, **kwargs):
+        """Send a POST request to an endpoint."""
+
+        # Encode JSON data
+        if kwargs.get('data'):
+            kwargs['data'] = json.dumps(kwargs.get('data'))
+
+        response = self.session.post(
+            urljoin(self.basepath, path),
+            **kwargs,
+        )
+
+        response.__class__ = DoxieResponse
+        response.raise_for_status()
+
+        return response
+
+    def _delete(self, path, **kwargs):
+        """Send a DELETE request to an endpoint."""
+
+        response = self.session.delete(
+            urljoin(self.basepath, path),
+            **kwargs,
+        )
+
+        response.__class__ = DoxieResponse
+        response.raise_for_status()
+
         return response
 
     def _fetch_attributes(self, attribute=None):
@@ -158,10 +186,10 @@ class DoxieScanner:
         If 'attribute' provided, we will attempt to load it, and raise an error
         if not found.
         """
-        self._attributes.update(self._api_call("/hello.json"))
+        self._attributes.update(self._get("hello.json").json())
         if attribute and attribute not in self._attributes:
             # Additional call for more information
-            self._attributes.update(self._api_call("/hello_extra.json"))
+            self._attributes.update(self._get("hello_extra.json").json())
 
         if attribute:
             # Raises KeyError if doesn't exist
@@ -192,7 +220,7 @@ class DoxieScanner:
         """
         Returns a list of scans available on the Doxie
         """
-        return self._api_call("/scans.json")
+        return self._get("scans.json").json()
 
     @property
     def recent(self):
@@ -201,26 +229,29 @@ class DoxieScanner:
         This seems to be cached on the Doxie and may refer to a scan
         which has subsequently been deleted.
         """
-        return self._api_call("/scans/recent.json")['path']
+        response = self._get("scans/recent.json")
+        if response.status_code == requests.codes.no_content:
+            # No recent scan
+            return None
+
+        return response.json()['path']
 
     def restart_wifi(self):
         """
         Restarts the wifi on the Doxie
         """
-        self._api_call("/restart.json", return_json=False)
+        response = self._get("restart.json")
+        return response.status_code == requests.codes.no_content
 
-    def download_scan(self, path, output_dir):
+    def download_scan(self, name, output_dir):
         """
-        Downloads a scan at the given path to the given local dir,
+        Downloads a scan at the given name to the given local dir,
         preserving the filename.
         Will raise an exception if the target file already exists.
         Returns the path of the downloaded file.
         """
-        if not path.startswith("/scans"):
-            path = "/scans{}".format(path)
-        url = self._api_url(path)
-        response = self._get_url(url, stream=True)
-        output_path = os.path.join(output_dir, os.path.basename(path))
+        response = self._get('scans' + name, stream=True)
+        output_path = os.path.join(output_dir, os.path.basename(name))
         if os.path.isfile(output_path):
             raise FileExistsError(output_path)
         with open(output_path, 'wb') as output:
@@ -243,7 +274,7 @@ class DoxieScanner:
             output_files.append(self.download_scan(scan['name'], output_dir))
         return output_files
 
-    def delete_scan(self, path, retries=3, timeout=5):
+    def delete_scan(self, name, retries=3, timeout=5):
         """
         Deletes a scan from the Doxie.
         This method may be slow; from the API docs:
@@ -256,18 +287,15 @@ class DoxieScanner:
         params.
         Returns a boolean indicating whether the deletion was successful.
         """
-        if not path.startswith("/scans"):
-            path = "/scans{}".format(path)
-        url = self._api_url(path)
         for attempt in range(retries):
-            response = self.session.delete(url)
+            response = self._delete('scans' + name)
             if response.status_code == requests.codes.no_content:
                 return True
             if attempt < retries-1:
                 time.sleep(timeout)
         return False
 
-    def delete_scans(self, paths, retries=3, timeout=5):
+    def delete_scans(self, names, retries=3, timeout=5):
         """
         Deletes multiple scans from the Doxie.
         This method may be slow; from the API docs:
@@ -282,9 +310,8 @@ class DoxieScanner:
         The deletion is considered successful by the Doxie if at least one scan
         was deleted, it seems.
         """
-        url = self._api_url("/scans/delete.json")
         for attempt in range(retries):
-            response = self.session.post(url, data=json.dumps(paths))
+            response = self._post("scans/delete.json", data=names)
             if response.status_code == requests.codes.no_content:
                 return True
             if attempt < retries-1:

--- a/doxieapi/api.py
+++ b/doxieapi/api.py
@@ -30,7 +30,7 @@ class DoxieScanner:
     # pylint: disable=too-many-instance-attributes
     # Nine is reasonable in this case.
 
-    url = None
+    basepath = None
     username = "doxie"  # This is always the same according to API docs
     password = None
 
@@ -45,8 +45,8 @@ class DoxieScanner:
     # so it's lazily loaded and cached via a @property
     _firmware = None
 
-    def __init__(self, url, load_attributes=True):
-        self.url = url
+    def __init__(self, basepath, load_attributes=True):
+        self.basepath = basepath
         self.session = requests.Session()
         if load_attributes:
             self._load_hello_attributes()
@@ -61,7 +61,7 @@ class DoxieScanner:
         'Doxie model DX250 (Doxie_00AAFF) at http://192.168.100.1:8080/'
         """
         return "Doxie model {} ({}) at {}".format(
-            self.model, self.name, self.url)
+            self.model, self.name, self.basepath)
 
     def __repr__(self):
         """
@@ -86,8 +86,8 @@ class DoxieScanner:
             if DOXIE_SSDP_SERVICE not in response.usn:
                 continue  # skip over non-Doxie responses
             scheme, netloc, _, _, _, _ = urlparse(response.location)
-            url = urlunparse((scheme, netloc, '/', '', '', ''))
-            doxies.append(DoxieScanner(url))
+            basepath = urlunparse((scheme, netloc, '/', '', '', ''))
+            doxies.append(DoxieScanner(basepath))
         return doxies
 
     def _api_url(self, path):
@@ -97,7 +97,7 @@ class DoxieScanner:
         >>> doxie._api_url("/networks/available.json")
         'http://192.168.100.1:8080/networks/available.json'
         """
-        return urljoin(self.url, path)
+        return urljoin(self.basepath, path)
 
     def _api_call(self, path, return_json=True):
         """

--- a/doxieapi/api.py
+++ b/doxieapi/api.py
@@ -56,6 +56,17 @@ class DoxieSession(requests.Session):
         self.mount('http://', adapter)
         self.mount('https://', adapter)
 
+    def request(self, **kwargs):
+        """Sends a request to a Doxie API instance.
+        Returns a DoxieResponse object.
+
+        """
+        response = super().request(**kwargs)
+        response.__class__ = DoxieResponse
+        response.raise_for_status()  # Raise errors as default behavior
+
+        return response
+
 
 class DoxieResponse(requests.Response):
     """A Response from a Doxie API call."""
@@ -167,15 +178,10 @@ class DoxieScanner:
     def _get(self, path, **kwargs):
         """Send a GET request to an endpoint."""
 
-        response = self.session.get(
+        return self.session.get(
             urljoin(self.basepath, path),
             **kwargs,
         )
-
-        response.__class__ = DoxieResponse
-        response.raise_for_status()
-
-        return response
 
     def _post(self, path, **kwargs):
         """Send a POST request to an endpoint."""
@@ -184,28 +190,18 @@ class DoxieScanner:
         if kwargs.get('data'):
             kwargs['data'] = json.dumps(kwargs.get('data'))
 
-        response = self.session.post(
+        return self.session.post(
             urljoin(self.basepath, path),
             **kwargs,
         )
-
-        response.__class__ = DoxieResponse
-        response.raise_for_status()
-
-        return response
 
     def _delete(self, path, **kwargs):
         """Send a DELETE request to an endpoint."""
 
-        response = self.session.delete(
+        return self.session.delete(
             urljoin(self.basepath, path),
             **kwargs,
         )
-
-        response.__class__ = DoxieResponse
-        response.raise_for_status()
-
-        return response
 
     def _fetch_attributes(self, attribute=None):
         """

--- a/doxieapi/api.py
+++ b/doxieapi/api.py
@@ -19,6 +19,12 @@ import requests
 from . import ssdp
 
 DOXIE_SSDP_SERVICE = "urn:schemas-getdoxie-com:device:Scanner:1"
+DOXIE_ATTR_MAP = {
+    'mac': 'MAC',
+    'firmware_wifi': 'firmwareWiFi',
+    'connected_to_external_power': 'connectedToExternalPower',
+    'has_password': 'hasPassword',
+}
 
 # Scans are downloaded in chunks of this many bytes:
 DOWNLOAD_CHUNK_SIZE = 1024*8
@@ -27,21 +33,11 @@ DOWNLOAD_CHUNK_SIZE = 1024*8
 class DoxieScanner:
     """A client for the Doxie Scanner."""
 
-    # pylint: disable=too-many-instance-attributes
-    # Nine is reasonable in this case.
-
     basepath = None
 
-    # These attributes will be populated by _load_hello_attributes
-    model = None
-    name = None
-    mac = None
-    mode = None
-    network = None
-    firmware_wifi = None
-    # This attribute comes from the 'hello_extra' API call, which is expensive
-    # so it's lazily loaded and cached via a @property
-    _firmware = None
+    # These attributes will be populated by 'hello' or 'hello_extra' API calls.
+    # By default we will pre-populate those from 'hello'.
+    _attributes = {}  # type: dict
 
     def __init__(self, basepath, password=None, load_attributes=True):
         """Create a client session to the Doxie API.
@@ -59,7 +55,10 @@ class DoxieScanner:
             self.session.auth = ('doxie', password)
 
         if load_attributes:
-            self._load_hello_attributes()
+            self._fetch_attributes()
+            if self.has_password and not self.session.auth:
+                # Set up authentication if possible
+                self.session.auth = self._load_password()
 
     def __str__(self):
         """
@@ -84,6 +83,27 @@ class DoxieScanner:
         http://192.168.100.1:8080/>'
         """
         return "<DoxieScanner: {}>".format(str(self))
+
+    def __getattr__(self, name):
+        """Attempts to retrieve an attribute of the Doxie model.
+        Raises an AttributeError if it fails.
+
+        """
+        # map snake_case naming to Doxie camelCasing if applicable
+        attr = DOXIE_ATTR_MAP.get(name) or name
+
+        # Returns cached attribute if exists
+        if attr in self._attributes:
+            return self._attributes[attr]
+
+        # Retrieves from API if possible
+        try:
+            return self._fetch_attributes(attr)
+        except KeyError as err:
+            raise AttributeError(
+                "'{}' object has no attribute '{}'".format(
+                    type(self).__name__, name)
+            ) from err
 
     @classmethod
     def discover(cls):
@@ -132,23 +152,22 @@ class DoxieScanner:
             response.raise_for_status()
         return response
 
-    def _load_hello_attributes(self):
+    def _fetch_attributes(self, attribute=None):
         """
-        Sets the values from the 'hello' API call as attributes
-        on this DoxieScanner instance.
-        If a password is required, it's loaded from the INI
-        file by _load_password()
+        Retrieves attributes from the 'hello' or 'hello_extra' API calls.
+        If 'attribute' provided, we will attempt to load it, and raise an error
+        if not found.
         """
-        attributes = self._api_call("/hello.json")
-        self.model = attributes['model']
-        self.name = attributes['name']
-        self.mac = attributes['MAC']
-        self.mode = attributes['mode']
-        self.firmware_wifi = attributes['firmwareWiFi']
-        if self.mode == "Client":
-            self.network = attributes['network']
-        if attributes['hasPassword'] and not self.session.auth:
-            self._load_password()
+        self._attributes.update(self._api_call("/hello.json"))
+        if attribute and attribute not in self._attributes:
+            # Additional call for more information
+            self._attributes.update(self._api_call("/hello_extra.json"))
+
+        if attribute:
+            # Raises KeyError if doesn't exist
+            return self._attributes[attribute]
+
+        return True
 
     def _load_password(self):
         """
@@ -161,37 +180,12 @@ class DoxieScanner:
         config = ConfigParser()
         config.read(config_path)
         try:
-            self.session.auth = ('doxie', config[self.mac]['password'])
+            return ('doxie', config[self.mac]['password'])
         except KeyError as err:
             raise Exception(
                 "Couldn't find password for Doxie {} in {}".format(
                     self.mac, config_path)
             ) from err
-
-    @property
-    def firmware(self):
-        """
-        Fetches and caches the 'firmware' string from the 'hello_extra' API
-        call. This call is expensive and the value isn't going to change, so
-        we're fine to cache it for the lifetime of this DoxieScanner instance.
-        """
-        if self._firmware is None:
-            self._firmware = self._api_call("/hello_extra.json")['firmware']
-        return self._firmware
-
-    @property
-    def connected_to_external_power(self):
-        """
-        Returns True if the scanner is connected to AC power.
-        This uses the 'hello_extra' API call which is expensive according to
-        the docs.
-        Doesn't cache the value as it might change.
-        """
-        attributes = self._api_call("/hello_extra.json")
-        # hello_extra is an expensive call so might as well
-        # cache the firmware version while we're here...
-        self._firmware = attributes['firmware']
-        return attributes['connectedToExternalPower']
 
     @property
     def scans(self):

--- a/doxieapi/api.py
+++ b/doxieapi/api.py
@@ -47,6 +47,7 @@ class DoxieScanner:
 
     def __init__(self, url, load_attributes=True):
         self.url = url
+        self.session = requests.Session()
         if load_attributes:
             self._load_hello_attributes()
 
@@ -116,7 +117,7 @@ class DoxieScanner:
         Checks that the response status code is 200 before
         returning the response.
         """
-        response = requests.get(url, auth=self._get_auth(), stream=stream)
+        response = self.session.get(url, auth=self._get_auth(), stream=stream)
         if response.status_code != requests.codes.ok:
             response.raise_for_status()
         return response
@@ -266,7 +267,7 @@ class DoxieScanner:
         url = self._api_url(path)
         auth = self._get_auth()
         for attempt in range(retries):
-            response = requests.delete(url, auth=auth)
+            response = self.session.delete(url, auth=auth)
             if response.status_code == requests.codes.no_content:
                 return True
             if attempt < retries-1:
@@ -291,7 +292,8 @@ class DoxieScanner:
         url = self._api_url("/scans/delete.json")
         auth = self._get_auth()
         for attempt in range(retries):
-            response = requests.post(url, auth=auth, data=json.dumps(paths))
+            response = self.session.post(url, auth=auth,
+                                         data=json.dumps(paths))
             if response.status_code == requests.codes.no_content:
                 return True
             if attempt < retries-1:


### PR DESCRIPTION
A major rewrite to the Doxie client's session handler, including how attributes are retrieved and stored, and how API calls are made.

### DoxieResponse and DoxieSession

All requests now use a common requests session to perform tasks. `DoxieSession` is a requests session instance for a Doxie scanner, handling authentication, retry logic, and requests to the Doxie API. Errors are raised automatically if retries fail, and all requests return a `DoxieResponse`.

`DoxieResponse` is a custom response object, defining 401 and 403 as the two error codes that the Doxie API will raise.

### Doxie attribute retrieval and handling

Newer Doxie firmwares provide more information on the 'hello' API call, and return nothing on 'hello_extra'. There are also some newer properties, and some missing ones depending on the hardware model.

The new logic will attempt to load attributes from 'hello' first, falling back to 'hello_extra' if not found. If an attribute is specified, we raise an exception as normal behavior.

For attributes we know the name of, a mapping has been provided where we wish to translate from camelCase to snake_case, maintaining compatibility with expected attribute names that existed before.

### Functional changes

* DoxieScanner now accepts `password` as an argument to provide authentication to a Doxie scanner.
* DoxieScanner argument for API base changed to `basepath` from `url`, to avoid confusion with endpoints.
* DoxieScanner now automatically raises `HTTPError` on errors, and only for 401 (Unauthorized) or 403 (Forbidden) errors.
* Automatic retry for 401 and 403 errors exists, due to Doxie scanners being flaky with authentication and task handling.